### PR TITLE
Add support for HTTP DELETE method

### DIFF
--- a/src/oauth.erl
+++ b/src/oauth.erl
@@ -1,7 +1,10 @@
 -module(oauth).
 
--export([get/3, get/5, get/6, post/3, post/5, post/6, put/6, put/7, uri/2, header/1,
-  sign/6, params_decode/1, token/1, token_secret/1, verify/6]).
+-export([get/3, get/5, get/6,
+  post/3, post/5, post/6,
+  delete/3, delete/5, delete/6,
+  put/6, put/7,
+  uri/2, header/1, sign/6, params_decode/1, token/1, token_secret/1, verify/6]).
 
 -export([plaintext_signature/2, hmac_sha1_signature/5,
   hmac_sha1_signature/3, rsa_sha1_signature/4, rsa_sha1_signature/2,
@@ -34,6 +37,16 @@ post(URL, ExtraParams, Consumer, Token, TokenSecret) ->
 post(URL, ExtraParams, Consumer, Token, TokenSecret, HttpcOptions) ->
   SignedParams = sign("POST", URL, ExtraParams, Consumer, Token, TokenSecret),
   http_request(post, {URL, [], "application/x-www-form-urlencoded", uri_params_encode(SignedParams)}, HttpcOptions).
+
+delete(URL, ExtraParams, Consumer) ->
+  delete(URL, ExtraParams, Consumer, "", "").
+
+delete(URL, ExtraParams, Consumer, Token, TokenSecret) ->
+  delete(URL, ExtraParams, Consumer, Token, TokenSecret, []).
+
+delete(URL, ExtraParams, Consumer, Token, TokenSecret, HttpcOptions) ->
+  SignedParams = sign("DELETE", URL, ExtraParams, Consumer, Token, TokenSecret),
+  http_request(delete, {URL, [], "application/x-www-form-urlencoded", uri_params_encode(SignedParams)}, HttpcOptions).
 
 put(URL, ExtraParams, {ContentType, Body}, Consumer, Token, TokenSecret) ->
   put(URL, ExtraParams, {ContentType, Body}, Consumer, Token, TokenSecret, []).


### PR DESCRIPTION
Adding support for DELETE method to be able to use this library with APIs like [Trello](https://developers.trello.com/reference/#actionsid-1), which use Oauth1.0.